### PR TITLE
Temp: Add commands to clear out left-over secrets in CI build

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -66,6 +66,9 @@ steps:
     go get -u golang.org/x/tools/cmd/cover
     go get -u github.com/AlekSi/gocov-xml
     go get -u github.com/matm/gocov-html
+    # clean out left-over test secrets
+    curl -X POST -H "Authorization: Bearer $DATABRICKS_TOKEN" -H "ContentType: application/json" $DATABRICKS_HOST/api/2.0/secrets/scopes/delete --data '{"scope": "secretscope-with-acls"}' 
+    curl -X POST -H "Authorization: Bearer $DATABRICKS_TOKEN" -H "ContentType: application/json" $DATABRICKS_HOST/api/2.0/secrets/scopes/delete --data '{"scope": "secretscope-with-secrets"}'
     # run test
     make test
   continueOnError: 'false'


### PR DESCRIPTION
Temporary PR to have a build that clears out secrets left over from previous test runs to workaround errors such as found in [this build](https://dev.azure.com/ms/azure-databricks-operator/_build/results?buildId=51567)

My assumption is that this will be rendered unnecessary by #101 at some point?

```log
2019-11-26T08:55:52.540Z	ERROR	controller-runtime.controller	Reconciler error	{"controller": "secretscope", "request": "default/secretscope-with-secrets", "error": "error when submitting secret scope to the API: Response from server (400) {\"error_code\":\"RESOURCE_ALREADY_EXISTS\",\"message\":\"Scope secretscope-with-secrets already exists!\"}"}
github.com/go-logr/zapr.(*zapLogger).Error
	/home/vsts/work/1/s/gopath/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/vsts/work/1/s/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:218
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/vsts/work/1/s/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:192
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/home/vsts/work/1/s/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0-beta.4/pkg/internal/controller/controller.go:171
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
	/home/vsts/work/1/s/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/home/vsts/work/1/s/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
	/home/vsts/work/1/s/gopath/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:88
```