### PR TITLE
Changes for requeuing the terminal state jobs

### DIFF
--- a/api/v1alpha1/run_types.go
+++ b/api/v1alpha1/run_types.go
@@ -64,6 +64,18 @@ func (run *Run) IsSubmitted() bool {
 	return run.Status.Metadata.JobID > 0
 }
 
+// IsTerminated return true if item is in terminal state
+func (run *Run) IsTerminated() bool {
+	if run.Status == nil || run.Status.Metadata.State == nil || run.Status.Metadata.State.LifeCycleState == nil {
+		return false
+	}
+	switch *run.Status.Metadata.State.LifeCycleState {
+	case dbmodels.RunLifeCycleStateTerminated, dbmodels.RunLifeCycleStateSkipped, dbmodels.RunLifeCycleStateInternalError:
+		return true
+	}
+	return false
+}
+
 // RunFinalizerName is the name of the run finalizer
 const RunFinalizerName = "run.finalizers.databricks.microsoft.com"
 

--- a/controllers/run_controller.go
+++ b/controllers/run_controller.go
@@ -100,7 +100,9 @@ func (r *RunReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Refreshed", "Object is refreshed")
 	}
-
+	if instance.IsTerminated() {
+		return ctrl.Result{}, nil
+	}
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 }
 


### PR DESCRIPTION
The below graphs show the results when the Run in terminal state are removed from the reconciliation requeue

The following graph shows the similar load patter as we have used before.
 
<img width="659" alt="Screenshot 2020-01-22 at 12 14 59" src="https://user-images.githubusercontent.com/31089923/72893415-d7f2b500-3d10-11ea-878e-0ad31a339e92.png">


And the graph below shows the reconciliation rate for the same time period:
<img width="691" alt="Screenshot 2020-01-22 at 12 13 34" src="https://user-images.githubusercontent.com/31089923/72893365-bdb8d700-3d10-11ea-9b4a-210cce6aac15.png">



