### PR TITLE
Fix issue with invalid yaml on latest kubectl versions

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -16,4 +16,5 @@ spec:
       tlsConfig:
         insecureSkipVerify: true # Configure certs here if set up for auth_proxy (uses self-signed currently)
   selector:
-    control-plane: controller-manager
+    matchLabels:
+      control-plane: controller-manager


### PR DESCRIPTION
When deploy the operator with `kubectl version v1.17.2` you encounter the error:

```bash
error: error validating "./deploy/azure-databricks-operator/manifest-temp/run-duration-metrics-with-reconciler-config-20200203.1/default": error validating data:
ValidationError(ServiceMonitor.spec.selector): unknown field "control-plane" in com.coreos.monitoring.v1.ServiceMonitor.spec.selector; 
if you choose to ignore these errors, turn validation off with --validate=false
```

Which is cause by invalid yaml in the  'config/prometheus/monitor.yaml'