### PR TITLE
Add multiple pods with anti affinity

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,12 +16,22 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: control-plane
+                  operator: In
+                  values:
+                  - controller-manager
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - command:
         - /manager


### PR DESCRIPTION
This PR is to address the issue [#164 Operator becomes unavailable if pod restarts](#164). We've increased the operator pod count to 2 and the pods will be deployed on different nodes to keep the operator operational in case a pod or a node goes down.

We've also tested that this change has no negative effect on the performance of the operator, the results of the test can be seen below:
![image](https://user-images.githubusercontent.com/12761692/74329793-61355e80-4d88-11ea-9bc8-35875e7d5bce.png)
![image](https://user-images.githubusercontent.com/12761692/74329800-65617c00-4d88-11ea-9d8f-ca9a18bb8150.png)
